### PR TITLE
Resolve submission serialization

### DIFF
--- a/hfysubs/inbox.py
+++ b/hfysubs/inbox.py
@@ -17,10 +17,12 @@ def extract_users(message):
 
 
 def handle_inbox_stream():
-    for message in make_reddit().inbox.stream():
+    reddit = make_reddit()
+
+    for message in reddit.inbox.stream():
         if "unsubscribe" in message.body.lower() or "unsubscribe" in message.subject.lower():
             for user in extract_users(message.body):
-                print("Removing subscription from %s to %s" % (user, message.author))
+                logger("Removing subscription from %s to %s" % (user, message.author))
                 config.remove_subscription(user, message.author)
 
             send_message.delay(
@@ -33,7 +35,7 @@ def handle_inbox_stream():
                 if user.lower() == 'u':
                     continue
                 else:
-                    print("Added subscription from %s to %s" % (user, message.author))
+                    logger("Added subscription from %s to %s" % (user, message.author))
                     config.add_subscription(user, message.author)
 
             send_message.delay(
@@ -46,6 +48,13 @@ def handle_inbox_stream():
 
 
 def construct_pm(author, subscriptions):
+    """
+    :type author: str
+    :type subscriptions: (str)[]
+
+    :rtype: str
+    """
+
     subscriptions = [subscription[0] for subscription in subscriptions]
     if len(subscriptions) >= 1:
         subscriptions[0] = "* /u/" + subscriptions[0]

--- a/hfysubs/submissions.py
+++ b/hfysubs/submissions.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from .reddit import make_reddit
 from beetusbot import config
-from .tasks import process_submission
+from .tasks import process_submission, SerializableSubmission
 from .util import filter_post
 
 
@@ -10,7 +10,16 @@ def handle_subscription_stream():
     subreddit = make_reddit().subreddit(config.SUBREDDIT)
 
     for submission in subreddit.stream.submissions():
-        previous_id = config.get_post_in_thread(submission.id)  #checks if the story/submission is already in the 'repliedto' database.
+        # checks if the story/submission is already in the 'repliedto' database.
+        previous_id = config.get_post_in_thread(submission.id)
         # author may be None when a user deletes itself as author right away
-	if (not previous_id) and filter_post(submission) and submission.author is not None:
-		process_submission(submission)
+        if (not previous_id) and filter_post(submission) and submission.author is not None:
+            # Convert the submission into something we can be sure will get serialized properly
+            serializable_sub = SerializableSubmission(
+                submission.id,
+                submission.author.name,
+                submission.title.encode('utf-8'),
+                submission.url
+            )
+
+            process_submission(serializable_sub)

--- a/hfysubs/tasks/__init__.py
+++ b/hfysubs/tasks/__init__.py
@@ -1,9 +1,10 @@
 from .reddit_writer import send_message, write_post
-from .submissions import process_submission, queue_notifications
+from .submissions import process_submission, queue_notifications, SerializableSubmission
 
 __ALL__ = [
     send_message,
     write_post,
     process_submission,
-    queue_notifications
+    queue_notifications,
+    SerializableSubmission
 ]

--- a/hfysubs/util.py
+++ b/hfysubs/util.py
@@ -1,5 +1,9 @@
 from beetusbot import config
 
+from celery.utils.log import get_task_logger
+
+logger = get_task_logger(__name__)
+
 
 def filter_post(post):
     if post.subreddit.display_name.lower() != config.SUBREDDIT.lower():


### PR DESCRIPTION
This commit should resolve the submission serialization issue by no longer attempting to serialize praw.Models.Submission.

Instead, before calling `process_submission` we create a `namedtuple` containing all of the data we need from the real submission.

We then reconstruct this `namedtuple` at the start of every function that may receive a serialized version of it.

This PR also add type hinting docstrings to the task methods. (I did this to keep track of where I was up to while verifying all other task parameters should be serializable)